### PR TITLE
Disabling dev entry point.

### DIFF
--- a/symfony/web/app_dev.php
+++ b/symfony/web/app_dev.php
@@ -14,7 +14,7 @@ if (isset($_SERVER['HTTP_CLIENT_IP'])
     || !in_array(@$_SERVER['REMOTE_ADDR'], array('127.0.0.1', 'fe80::1', '::1'))
 ) {
     header('HTTP/1.0 403 Forbidden');
-//    exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');
+    exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');
 }
 
 $loader = require_once __DIR__.'/../app/bootstrap.php.cache';


### PR DESCRIPTION
For more security, either enabling that `exit` or block access to any `app_*.php` via webserver.
